### PR TITLE
Fix spurious error banners

### DIFF
--- a/js/gamebanners.js
+++ b/js/gamebanners.js
@@ -45,7 +45,6 @@ function updateBanners(server) {
     banner.querySelector(`#${server.identifier}-hub`),
     banner.querySelector(`#${server.identifier}-bunker`)
   );
-  setBannerToErrorMode(banner, "", true);
   return getPlayerCount(server);
 }
 
@@ -164,13 +163,11 @@ function pad(n, width, z) {
   return n.length >= width ? n : new Array(width - n.length + 1).join(z) + n;
 }
 
-function setBannerToErrorMode(banner, errorText, undo = false) {
-  if (!undo) {
-    banner.classList.add("error");
-    banner.classList.remove("underway", "lobby", "end");
-    banner.querySelector(".version").textContent = errorText;
-  } else {
-  }
+function setBannerToErrorMode(banner, errorText) {
+  banner.classList.add("error");
+  banner.classList.remove("underway", "lobby", "end");
+  banner.querySelector(".version").textContent = errorText;
+
 }
 
 function getPlayerCount(server) {

--- a/js/gamebanners.js
+++ b/js/gamebanners.js
@@ -128,6 +128,7 @@ function shuttleTime(shuttlemode, shuttletime) {
 
 function state2class(state, target) {
   target.classList.remove("loading");
+  target.classList.remove("error");
   switch (Number(state)) {
     case 2:
     case 3:


### PR DESCRIPTION
SetBannerToErrorMode(...) was being called with an undo argument that never does anything.
Consequently, once a server's banner is set to an error mode it can never be undone. 

This fixes that, and makes the code slightly cleaner. (A method called `setBannerToErrorMode()` shouldn't be responsible for unsetting that mode.)