### PR TITLE
Preserve aspect ratio on small-width screens

### DIFF
--- a/index.njk
+++ b/index.njk
@@ -86,7 +86,7 @@
         <img
           src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNzI4IiBoZWlnaHQ9IjkwIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxyZWN0IHdpZHRoPSI3MjgiIGhlaWdodD0iOTAiIGZpbGw9IiM3ZjdjODAiLz48dGV4dCB4PSI1MCUiIHk9IjUwJSIgZG9taW5hbnQtYmFzZWxpbmU9ImNlbnRyYWwiIHRleHQtYW5jaG9yPSJtaWRkbGUiIGZpbGw9IiMwMDAiIGZvbnQtZmFtaWx5PSJBcmlhbCwgSGVsdmV0aWNhLCBzYW5zLXNlcmlmIiBmb250LXNpemU9IjMwIj5sb2FkaW5nLi4uPC90ZXh0Pjwvc3ZnPg=="
           width="728"
-          height="90">
+          height="auto">
         <script>
           const banners = {{ banners | dump | safe }};
           let banner = banners[Math.floor(Math.random() * banners.length)]


### PR DESCRIPTION
There's an issue with the supporter banners on small-width screens - the height is statically defined as 90px, however the max-width: auto attribute on the image class is causing the aspect ratio to get borked when the width is reduced.

This can be fixed by setting the height to auto so the aspect ratio can be properly preserved when width gets low.

Here's a gif showing the before and after:

<img width="1059" height="1027" alt="supbanner-ratiofix" src="https://github.com/user-attachments/assets/5a3621b7-8483-4f1b-8d83-c945d62e2474" />
